### PR TITLE
allow loading in browser via es modules

### DIFF
--- a/src/bates.js
+++ b/src/bates.js
@@ -1,5 +1,5 @@
-import defaultSource from "./defaultSource";
-import irwinHall from "./irwinHall";
+import defaultSource from "./defaultSource.js";
+import irwinHall from "./irwinHall.js";
 
 export default (function sourceRandomBates(source) {
   function randomBates(n) {

--- a/src/exponential.js
+++ b/src/exponential.js
@@ -1,4 +1,4 @@
-import defaultSource from "./defaultSource";
+import defaultSource from "./defaultSource.js";
 
 export default (function sourceRandomExponential(source) {
   function randomExponential(lambda) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-export {default as randomUniform} from "./uniform";
-export {default as randomNormal} from "./normal";
-export {default as randomLogNormal} from "./logNormal";
-export {default as randomBates} from "./bates";
-export {default as randomIrwinHall} from "./irwinHall";
-export {default as randomExponential} from "./exponential";
+export {default as randomUniform} from "./uniform.js";
+export {default as randomNormal} from "./normal.js";
+export {default as randomLogNormal} from "./logNormal.js";
+export {default as randomBates} from "./bates.js";
+export {default as randomIrwinHall} from "./irwinHall.js";
+export {default as randomExponential} from "./exponential.js";

--- a/src/irwinHall.js
+++ b/src/irwinHall.js
@@ -1,4 +1,4 @@
-import defaultSource from "./defaultSource";
+import defaultSource from "./defaultSource.js";
 
 export default (function sourceRandomIrwinHall(source) {
   function randomIrwinHall(n) {

--- a/src/logNormal.js
+++ b/src/logNormal.js
@@ -1,5 +1,5 @@
-import defaultSource from "./defaultSource";
-import normal from "./normal";
+import defaultSource from "./defaultSource.js";
+import normal from "./normal.js";
 
 export default (function sourceRandomLogNormal(source) {
   function randomLogNormal() {

--- a/src/normal.js
+++ b/src/normal.js
@@ -1,4 +1,4 @@
-import defaultSource from "./defaultSource";
+import defaultSource from "./defaultSource.js";
 
 export default (function sourceRandomNormal(source) {
   function randomNormal(mu, sigma) {

--- a/src/uniform.js
+++ b/src/uniform.js
@@ -1,4 +1,4 @@
-import defaultSource from "./defaultSource";
+import defaultSource from "./defaultSource.js";
 
 export default (function sourceRandomUniform(source) {
   function randomUniform(min, max) {


### PR DESCRIPTION
Browser implementations of `import` do not assume a `.js` file extension. As such, the relative imports used in `d3-random` all fail with a 404, because the actual files on disk _do_ have `.js` extensions, while the corresponding `import` statements in the code do not.

This PR fixes the issue by simply adding explicit `.js` extensions to all `import` statements, thereby allowing the native browser implementations of ES Modules to successfully load these imports.