### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Returns a function for generating random numbers with an [exponential distributi
 
 <a name="random_source" href="#random_source">#</a> <i>random</i>.<b>source</b>(<i>source</i>)
 
-Returns the same type of function for generating random numbers but where the given random number generator *source* is used as the source of randomness instead of Math.random. The given random number generator must implement the same interface as Math.random and only return values in the range [0, 1). This is useful when a seeded random number generator is preferable to Math.random. For example:
+Returns the same type of function for generating random numbers but where the given random number generator *source* is used as the source of randomness instead of Math.random. The given random number generator must implement the same interface as Math.random and only return values in the range [0, 1]. This is useful when a seeded random number generator is preferable to Math.random. For example:
 
 ```js
 var d3 = require("d3-random"),


### PR DESCRIPTION
I changed a parentheses to a square braces:
[0, 1) -> [0, 1]