### PR TITLE
Gamma, Weibull, Poisson distributions, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Returns a function for generating random numbers with a [beta distribution](http
 
 Returns a function for generating random numbers with a [Weibull distribution](https://en.wikipedia.org/wiki/Weibull_distribution) with *lambda* the scale parameter and *k* the shape parameter. The value *k* must be a positive value.
 
+<a name="randomCauchy" href="#randomCauchy">#</a> d3.<b>randomCauchy</b>([<i>a</i>], [<i>b</i>]) · [Source](https://github.com/d3/d3-random/blob/master/src/cauchy.js), [Examples](https://observablehq.com/@parcly-taxel/cauchy-and-logistic-distributions)
+
+Returns a function for generating random numbers with a [Cauchy distribution](https://en.wikipedia.org/wiki/Cauchy_distribution) with *a* the location parameter and *b* the scale parameter. If *a* is not specified, it defaults to 0; if *b* is not specified, it defaults to 1.
+
+<a name="randomLogistic" href="#randomLogistic">#</a> d3.<b>randomLogistic</b>([<i>a</i>], [<i>b</i>]) · [Source](https://github.com/d3/d3-random/blob/master/src/logistic.js), [Examples](https://observablehq.com/@parcly-taxel/cauchy-and-logistic-distributions)
+
+Returns a function for generating random numbers with a [logistic distribution](https://en.wikipedia.org/wiki/Logistic_distribution). Parameter meanings and default values are the same as with d3.randomCauchy().
+
 <a name="random_source" href="#random_source">#</a> <i>random</i>.<b>source</b>(<i>source</i>) · [Examples](https://observablehq.com/@d3/random-source)
 
 Returns the same type of function for generating random numbers but where the given random number generator *source* is used as the source of randomness instead of Math.random. The given random number generator must implement the same interface as Math.random and only return values in the range [0, 1). This is useful when a seeded random number generator is preferable to Math.random. For example:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Returns a function for generating either 1 or 0 according to a [Bernoulli distri
 
 <a name="randomGeometric" href="#randomGeometric">#</a> d3.<b>randomGeometric</b>(<i>p</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/geometric.js), [Examples](https://observablehq.com/@d3/d3-random#geometric)
 
-Returns a function for generating numbers with a [geometric distribution](https://en.wikipedia.org/wiki/Geometric_distribution) with success probability *p*. The value *p* is in the range (0, 1].
+Returns a function for generating numbers with a [geometric distribution](https://en.wikipedia.org/wiki/Geometric_distribution) with success probability *p*. The value *p* is in the range [0, 1].
 
 <a name="randomBinomial" href="#randomBinomial">#</a> d3.<b>randomBinomial</b>(<i>n</i>, <i>p</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/binomial.js), [Examples](https://observablehq.com/@d3/d3-random#binomial)
 

--- a/README.md
+++ b/README.md
@@ -81,17 +81,23 @@ Returns a function for generating random numbers with a [gamma distribution](htt
 
 Returns a function for generating random numbers with a [beta distribution](https://en.wikipedia.org/wiki/Beta_distribution) with *alpha* and *beta* shape parameters, which must both be positive.
 
-<a name="randomWeibull" href="#randomWeibull">#</a> d3.<b>randomWeibull</b>(<i>lambda</i>, <i>k</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/weibull.js), [Examples](https://observablehq.com/@troymagennis/weibull-distribution)
+<a name="randomWeibull" href="#randomWeibull">#</a> d3.<b>randomWeibull</b>(<i>k</i>, [<i>a</i>], [<i>b</i>]) · [Source](https://github.com/d3/d3-random/blob/master/src/weibull.js), [Examples](https://observablehq.com/@parcly-taxel/frechet-gumbel-weibull)
 
-Returns a function for generating random numbers with a [Weibull distribution](https://en.wikipedia.org/wiki/Weibull_distribution) with *lambda* the scale parameter and *k* the shape parameter. The value *k* must be a positive value.
+Returns a function for generating random numbers with one of the [generalized extreme value distributions](https://en.wikipedia.org/wiki/Generalized_extreme_value_distribution), depending on *k*:
+
+* If *k* is positive, the [Weibull distribution](https://en.wikipedia.org/wiki/Weibull_distribution) with shape parameter *k*
+* If *k* is zero, the [Gumbel distribution](https://en.wikipedia.org/wiki/Gumbel_distribution)
+* If *k* is negative, the [Fréchet distribution](https://en.wikipedia.org/wiki/Fréchet_distribution) with shape parameter −*k*
+
+In all three cases, *a* is the location parameter and *b* is the scale parameter. If *a* is not specified, it defaults to 0; if *b* is not specified, it defaults to 1.
 
 <a name="randomCauchy" href="#randomCauchy">#</a> d3.<b>randomCauchy</b>([<i>a</i>], [<i>b</i>]) · [Source](https://github.com/d3/d3-random/blob/master/src/cauchy.js), [Examples](https://observablehq.com/@parcly-taxel/cauchy-and-logistic-distributions)
 
-Returns a function for generating random numbers with a [Cauchy distribution](https://en.wikipedia.org/wiki/Cauchy_distribution) with *a* the location parameter and *b* the scale parameter. If *a* is not specified, it defaults to 0; if *b* is not specified, it defaults to 1.
+Returns a function for generating random numbers with a [Cauchy distribution](https://en.wikipedia.org/wiki/Cauchy_distribution). *a* and *b* have the same meanings and default values as in d3.randomWeibull.
 
 <a name="randomLogistic" href="#randomLogistic">#</a> d3.<b>randomLogistic</b>([<i>a</i>], [<i>b</i>]) · [Source](https://github.com/d3/d3-random/blob/master/src/logistic.js), [Examples](https://observablehq.com/@parcly-taxel/cauchy-and-logistic-distributions)
 
-Returns a function for generating random numbers with a [logistic distribution](https://en.wikipedia.org/wiki/Logistic_distribution). Parameter meanings and default values are the same as with d3.randomCauchy().
+Returns a function for generating random numbers with a [logistic distribution](https://en.wikipedia.org/wiki/Logistic_distribution). *a* and *b* have the same meanings and default values as in d3.randomWeibull.
 
 <a name="randomPoisson" href="#randomPoisson">#</a> d3.<b>randomPoisson</b>(<i>lambda</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/poisson.js), [Examples](https://observablehq.com/@parcly-taxel/the-poisson-distribution)
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Returns a function for generating random numbers with a [log-normal distribution
 
 <a name="randomBates" href="#randomBates">#</a> d3.<b>randomBates</b>(<i>n</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/bates.js), [Examples](https://observablehq.com/@d3/d3-random#bates)
 
-Returns a function for generating random numbers with a [Bates distribution](https://en.wikipedia.org/wiki/Bates_distribution) with *n* independent variables.
+Returns a function for generating random numbers with a [Bates distribution](https://en.wikipedia.org/wiki/Bates_distribution) with *n* independent variables. The case of fractional *n* is handled as with d3.randomIrwinHall, and d3.randomBates(0) is equivalent to d3.randomUniform().
 
 <a name="randomIrwinHall" href="#randomIrwinHall">#</a> d3.<b>randomIrwinHall</b>(<i>n</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/irwinHall.js), [Examples](https://observablehq.com/@d3/d3-random#irwinHall)
 
-Returns a function for generating random numbers with an [Irwin–Hall distribution](https://en.wikipedia.org/wiki/Irwin–Hall_distribution) with *n* independent variables.
+Returns a function for generating random numbers with an [Irwin–Hall distribution](https://en.wikipedia.org/wiki/Irwin–Hall_distribution) with *n* independent variables. If the fractional part of *n* is non-zero, this is treated as adding d3.randomUniform() times that fractional part to the integral part.
 
 <a name="randomExponential" href="#randomExponential">#</a> d3.<b>randomExponential</b>(<i>lambda</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/exponential.js), [Examples](https://observablehq.com/@d3/d3-random#exponential)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Returns a function for generating numbers with a [geometric distribution](https:
 
 Returns a function for generating random numbers with a [binomial distribution](https://en.wikipedia.org/wiki/Binomial_distribution) with *n* the number of trials and *p* the probability of success in each trial. The value *n* is greater or equal to 0, and the value *p* is in the range [0, 1].
 
+<a name="randomGamma" href="#randomGamma">#</a> d3.<b>randomGamma</b>(<i>k</i>, [<i>theta</i>]) · [Source](https://github.com/d3/d3-random/blob/master/src/gamma.js), [Examples](https://observablehq.com/@parcly-taxel/the-gamma-and-beta-distributions)
+
+Returns a function for generating random numbers with a [gamma distribution](https://en.wikipedia.org/wiki/Gamma_distribution) with *k* the shape parameter and *theta* the scale parameter. The value *k* must be a positive value; if *theta* is not specified, it defaults to 1.
+
+<a name="randomBeta" href="#randomBeta">#</a> d3.<b>randomBeta</b>(<i>alpha</i>, <i>beta</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/beta.js), [Examples](https://observablehq.com/@parcly-taxel/the-gamma-and-beta-distributions)
+
+Returns a function for generating random numbers with a [beta distribution](https://en.wikipedia.org/wiki/Beta_distribution) with *alpha* and *beta* shape parameters, which must both be positive.
+
 <a name="random_source" href="#random_source">#</a> <i>random</i>.<b>source</b>(<i>source</i>) · [Examples](https://observablehq.com/@d3/random-source)
 
 Returns the same type of function for generating random numbers but where the given random number generator *source* is used as the source of randomness instead of Math.random. The given random number generator must implement the same interface as Math.random and only return values in the range [0, 1). This is useful when a seeded random number generator is preferable to Math.random. For example:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Returns a function for generating random numbers with an [exponential distributi
 
 <a name="randomPareto" href="#randomPareto">#</a> d3.<b>randomPareto</b>(<i>alpha</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/pareto.js), [Examples](https://observablehq.com/@d3/d3-random#pareto)
 
-Returns a function for generating random numbers with an [Pareto distribution](https://en.wikipedia.org/wiki/Pareto_distribution) with the shape *alpha*. The value *alpha* must be a positive value.
+Returns a function for generating random numbers with a [Pareto distribution](https://en.wikipedia.org/wiki/Pareto_distribution) with the shape *alpha*. The value *alpha* must be a positive value.
 
 <a name="randomBernoulli" href="#randomBernoulli">#</a> d3.<b>randomBernoulli</b>(<i>p</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/bernoulli.js), [Examples](https://observablehq.com/@d3/d3-random#bernoulli)
 
@@ -92,6 +92,10 @@ Returns a function for generating random numbers with a [Cauchy distribution](ht
 <a name="randomLogistic" href="#randomLogistic">#</a> d3.<b>randomLogistic</b>([<i>a</i>], [<i>b</i>]) · [Source](https://github.com/d3/d3-random/blob/master/src/logistic.js), [Examples](https://observablehq.com/@parcly-taxel/cauchy-and-logistic-distributions)
 
 Returns a function for generating random numbers with a [logistic distribution](https://en.wikipedia.org/wiki/Logistic_distribution). Parameter meanings and default values are the same as with d3.randomCauchy().
+
+<a name="randomPoisson" href="#randomPoisson">#</a> d3.<b>randomPoisson</b>(<i>lambda</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/poisson.js), [Examples](https://observablehq.com/@parcly-taxel/the-poisson-distribution)
+
+Returns a function for generating random numbers with a [Poisson distribution](https://en.wikipedia.org/wiki/Poisson_distribution) with mean *lambda*.
 
 <a name="random_source" href="#random_source">#</a> <i>random</i>.<b>source</b>(<i>source</i>) · [Examples](https://observablehq.com/@d3/random-source)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Returns a function for generating random numbers with a [gamma distribution](htt
 
 Returns a function for generating random numbers with a [beta distribution](https://en.wikipedia.org/wiki/Beta_distribution) with *alpha* and *beta* shape parameters, which must both be positive.
 
+<a name="randomWeibull" href="#randomWeibull">#</a> d3.<b>randomWeibull</b>(<i>lambda</i>, <i>k</i>) · [Source](https://github.com/d3/d3-random/blob/master/src/weibull.js), [Examples](https://observablehq.com/@troymagennis/weibull-distribution)
+
+Returns a function for generating random numbers with a [Weibull distribution](https://en.wikipedia.org/wiki/Weibull_distribution) with *lambda* the scale parameter and *k* the shape parameter. The value *k* must be a positive value.
+
 <a name="random_source" href="#random_source">#</a> <i>random</i>.<b>source</b>(<i>source</i>) · [Examples](https://observablehq.com/@d3/random-source)
 
 Returns the same type of function for generating random numbers but where the given random number generator *source* is used as the source of randomness instead of Math.random. The given random number generator must implement the same interface as Math.random and only return values in the range [0, 1). This is useful when a seeded random number generator is preferable to Math.random. For example:

--- a/src/bates.js
+++ b/src/bates.js
@@ -3,6 +3,8 @@ import irwinHall from "./irwinHall.js";
 
 export default (function sourceRandomBates(source) {
   function randomBates(n) {
+    // use limiting distribution at n === 0
+    if ((n = +n) === 0) return source;
     var randomIrwinHall = irwinHall.source(source)(n);
     return function() {
       return randomIrwinHall() / n;

--- a/src/beta.js
+++ b/src/beta.js
@@ -7,7 +7,7 @@ export default (function sourceRandomBeta(source) {
         Y = gamma.source(source)(beta);
     return function() {
       var x = X();
-      return x / (x + Y());
+      return x === 0 ? 0 : x / (x + Y());
     };
   }
 

--- a/src/beta.js
+++ b/src/beta.js
@@ -1,0 +1,17 @@
+import defaultSource from "./defaultSource.js";
+import gamma from "./gamma.js";
+
+export default (function sourceRandomBeta(source) {
+  function randomBeta(alpha, beta) {
+    var X = gamma.source(source)(alpha),
+        Y = gamma.source(source)(beta);
+    return function() {
+      var x = X();
+      return x / (x + Y());
+    };
+  }
+
+  randomBeta.source = sourceRandomBeta;
+
+  return randomBeta;
+})(defaultSource);

--- a/src/binomial.js
+++ b/src/binomial.js
@@ -1,12 +1,31 @@
 import defaultSource from "./defaultSource.js";
+import beta from "./beta.js";
+import geometric from "./geometric.js";
 
 export default (function sourceRandomBinomial(source) {
   function randomBinomial(n, p) {
-    n = +n, p = +p;
+    n = +n;
+    if ((p = +p) >= 1) return () => n;
+    if (p <= 0) return () => 0;
     return function() {
-      var i = -1, x = 0;
-      while (++i < n) x += source() < p;
-      return x;
+      var acc = 0, nn = n, pp = p;
+      while (nn * pp > 16 && nn * (1 - pp) > 16) {
+        var i = Math.floor((nn + 1) * pp),
+            y = beta.source(source)(i, nn - i + 1)();
+        if (y <= pp) {
+          acc += i;
+          nn -= i;
+          pp = (pp - y) / (1 - y);
+        } else {
+          nn = i - 1;
+          pp /= y;
+        }
+      }
+      var sign = pp < 0.5,
+          pFinal = sign ? pp : 1 - pp,
+          g = geometric.source(source)(pFinal);
+      for (var s = g(), k = 0; s <= nn; ++k) s += g();
+      return acc + (sign ? k : nn - k);
     };
   }
 

--- a/src/cauchy.js
+++ b/src/cauchy.js
@@ -1,0 +1,15 @@
+import defaultSource from "./defaultSource.js";
+
+export default (function sourceRandomCauchy(source) {
+  function randomCauchy(a, b) {
+    a = a == null ? 0 : +a;
+    b = b == null ? 1 : +b;
+    return function() {
+      return a + b * Math.tan(Math.PI * source());
+    };
+  }
+
+  randomCauchy.source = sourceRandomCauchy;
+
+  return randomCauchy;
+})(defaultSource);

--- a/src/exponential.js
+++ b/src/exponential.js
@@ -3,7 +3,7 @@ import defaultSource from "./defaultSource.js";
 export default (function sourceRandomExponential(source) {
   function randomExponential(lambda) {
     return function() {
-      return -Math.log(1 - source()) / lambda;
+      return -Math.log1p(-source()) / lambda;
     };
   }
 

--- a/src/gamma.js
+++ b/src/gamma.js
@@ -1,0 +1,31 @@
+import defaultSource from "./defaultSource.js";
+import exponential from "./exponential.js";
+import normal from "./normal.js";
+
+export default (function sourceRandomGamma(source) {
+  function randomGamma(k, theta) {
+    if ((k = +k) <= 0) throw new RangeError("invalid k");
+    theta = theta == null ? 1 : +theta;
+    if (k === 1) return exponential.source(source)(1 / theta);
+
+    var randomNormal = normal.source(source)(),
+        d = (k < 1 ? k + 1 : k) - 1 / 3,
+        c = 1 / (3 * Math.sqrt(d)),
+        multiplier = k < 1 ? () => Math.pow(source(), 1 / k) : () => 1;
+    return function() {
+      do {
+        do {
+          var x = randomNormal(),
+              v = 1 + c * x;
+        } while (v <= 0);
+        v *= v * v;
+        var u = 1 - source();
+      } while (u >= 1 - 0.0331 * x * x * x * x && Math.log(u) >= 0.5 * x * x + d * (1 - v + Math.log(v)));
+      return d * v * multiplier() * theta;
+    };
+  }
+
+  randomGamma.source = sourceRandomGamma;
+
+  return randomGamma;
+})(defaultSource);

--- a/src/gamma.js
+++ b/src/gamma.js
@@ -1,12 +1,14 @@
 import defaultSource from "./defaultSource.js";
-import exponential from "./exponential.js";
 import normal from "./normal.js";
 
 export default (function sourceRandomGamma(source) {
   function randomGamma(k, theta) {
-    if ((k = +k) <= 0) throw new RangeError("invalid k");
+    if ((k = +k) < 0) throw new RangeError("invalid k");
+    // degenerate distribution if k === 0
+    if (k === 0) return () => 0;
     theta = theta == null ? 1 : +theta;
-    if (k === 1) return exponential.source(source)(1 / theta);
+    // exponential distribution if k === 1
+    if (k === 1) return () => -Math.log(1 - source()) * theta;
 
     var randomNormal = normal.source(source)(),
         d = (k < 1 ? k + 1 : k) - 1 / 3,

--- a/src/gamma.js
+++ b/src/gamma.js
@@ -8,7 +8,7 @@ export default (function sourceRandomGamma(source) {
     if (k === 0) return () => 0;
     theta = theta == null ? 1 : +theta;
     // exponential distribution if k === 1
-    if (k === 1) return () => -Math.log(1 - source()) * theta;
+    if (k === 1) return () => -Math.log1p(-source()) * theta;
 
     var randomNormal = normal.source(source)(),
         d = (k < 1 ? k + 1 : k) - 1 / 3,

--- a/src/geometric.js
+++ b/src/geometric.js
@@ -2,9 +2,12 @@ import defaultSource from "./defaultSource.js";
 
 export default (function sourceRandomGeometric(source) {
   function randomGeometric(p) {
-    if ((p = 1 - p) < 0 || p >= 1) throw new RangeError("invalid p");
+    if ((p = +p) < 0 || p > 1) throw new RangeError("invalid p");
+    if (p === 0) return () => Infinity;
+    if (p === 1) return () => 1;
+    p = Math.log1p(-p);
     return function() {
-      return 1 + Math.floor(Math.log(source()) / Math.log(p));
+      return 1 + Math.floor(Math.log1p(-source()) / p);
     };
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,3 +11,4 @@ export {default as randomGeometric} from "./geometric.js";
 export {default as randomBinomial} from "./binomial.js";
 export {default as randomGamma} from "./gamma.js";
 export {default as randomBeta} from "./beta.js";
+export {default as randomWeibull} from "./weibull.js";

--- a/src/index.js
+++ b/src/index.js
@@ -9,3 +9,5 @@ export {default as randomPareto} from "./pareto.js";
 export {default as randomBernoulli} from "./bernoulli.js";
 export {default as randomGeometric} from "./geometric.js";
 export {default as randomBinomial} from "./binomial.js";
+export {default as randomGamma} from "./gamma.js";
+export {default as randomBeta} from "./beta.js";

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,5 @@ export {default as randomBinomial} from "./binomial.js";
 export {default as randomGamma} from "./gamma.js";
 export {default as randomBeta} from "./beta.js";
 export {default as randomWeibull} from "./weibull.js";
+export {default as randomCauchy} from "./cauchy.js";
+export {default as randomLogistic} from "./logistic.js";

--- a/src/index.js
+++ b/src/index.js
@@ -14,3 +14,4 @@ export {default as randomBeta} from "./beta.js";
 export {default as randomWeibull} from "./weibull.js";
 export {default as randomCauchy} from "./cauchy.js";
 export {default as randomLogistic} from "./logistic.js";
+export {default as randomPoisson} from "./poisson.js";

--- a/src/irwinHall.js
+++ b/src/irwinHall.js
@@ -2,9 +2,10 @@ import defaultSource from "./defaultSource.js";
 
 export default (function sourceRandomIrwinHall(source) {
   function randomIrwinHall(n) {
+    if ((n = +n) <= 0) return () => 0;
     return function() {
-      for (var sum = 0, i = 0; i < n; ++i) sum += source();
-      return sum;
+      for (var sum = 0, i = n; i > 1; --i) sum += source();
+      return sum + i * source();
     };
   }
 

--- a/src/logistic.js
+++ b/src/logistic.js
@@ -1,0 +1,16 @@
+import defaultSource from "./defaultSource.js";
+
+export default (function sourceRandomLogistic(source) {
+  function randomLogistic(a, b) {
+    a = a == null ? 0 : +a;
+    b = b == null ? 1 : +b;
+    return function() {
+      var u = source();
+      return a + b * Math.log(u / (1 - u));
+    };
+  }
+
+  randomLogistic.source = sourceRandomLogistic;
+
+  return randomLogistic;
+})(defaultSource);

--- a/src/poisson.js
+++ b/src/poisson.js
@@ -1,0 +1,24 @@
+import defaultSource from "./defaultSource.js";
+import binomial from "./binomial.js";
+import gamma from "./gamma.js";
+
+export default (function sourceRandomPoisson(source) {
+  function randomPoisson(lambda) {
+    return function() {
+      var acc = 0, l = lambda;
+      while (l > 16) {
+        var n = Math.floor(0.875 * l),
+            t = gamma.source(source)(n)();
+        if (t > l) return acc + binomial.source(source)(n - 1, l / t)();
+        acc += n;
+        l -= t;
+      }
+      for (var s = -Math.log1p(-source()), k = 0; s <= l; ++k) s -= Math.log1p(-source());
+      return acc + k;
+    };
+  }
+
+  randomPoisson.source = sourceRandomPoisson;
+
+  return randomPoisson;
+})(defaultSource);

--- a/src/weibull.js
+++ b/src/weibull.js
@@ -1,0 +1,15 @@
+import defaultSource from "./defaultSource.js";
+
+export default (function sourcerandomWeibull(source) {
+  function randomWeibull(lambda, k) {
+    if ((k = +k) < 0) throw new RangeError("invalid k");
+    k = 1 / k;
+    return function() {
+      return lambda * Math.pow(-Math.log(1 - source()), k);
+    };
+  }
+
+  randomWeibull.source = sourcerandomWeibull;
+
+  return randomWeibull;
+})(defaultSource);

--- a/src/weibull.js
+++ b/src/weibull.js
@@ -5,7 +5,7 @@ export default (function sourcerandomWeibull(source) {
     if ((k = +k) < 0) throw new RangeError("invalid k");
     k = 1 / k;
     return function() {
-      return lambda * Math.pow(-Math.log(1 - source()), k);
+      return lambda * Math.pow(-Math.log1p(-source()), k);
     };
   }
 

--- a/src/weibull.js
+++ b/src/weibull.js
@@ -1,15 +1,22 @@
 import defaultSource from "./defaultSource.js";
 
-export default (function sourcerandomWeibull(source) {
-  function randomWeibull(lambda, k) {
-    if ((k = +k) < 0) throw new RangeError("invalid k");
-    k = 1 / k;
+export default (function sourceRandomWeibull(source) {
+  function randomWeibull(k, a, b) {
+    var outerFunc;
+    if ((k = +k) === 0) {
+      outerFunc = x => -Math.log(x);
+    } else {
+      k = 1 / k;
+      outerFunc = x => Math.pow(x, k);
+    }
+    a = a == null ? 0 : +a;
+    b = b == null ? 1 : +b;
     return function() {
-      return lambda * Math.pow(-Math.log1p(-source()), k);
+      return a + b * outerFunc(-Math.log1p(-source()));
     };
   }
 
-  randomWeibull.source = sourcerandomWeibull;
+  randomWeibull.source = sourceRandomWeibull;
 
   return randomWeibull;
 })(defaultSource);

--- a/test/bates-test.js
+++ b/test/bates-test.js
@@ -10,6 +10,8 @@ tape("d3.randomBates(n) returns random numbers with a mean of one-half", functio
   var randomBates = d3.randomBates.source(seedrandom("f330fbece4c1c99f"));
   test.inDelta(d3.mean(d3.range(10000).map(randomBates(1))), 0.5, 0.05);
   test.inDelta(d3.mean(d3.range(10000).map(randomBates(10))), 0.5, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomBates(1.5))), 0.5, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomBates(4.2))), 0.5, 0.05);
   test.end();
 });
 
@@ -17,6 +19,8 @@ tape("d3.randomBates(n) returns random numbers with a variance of 1 / (12 * n)",
   var randomBates = d3.randomBates.source(seedrandom("c4af5ee918417093"));
   test.inDelta(d3.variance(d3.range(10000).map(randomBates(1))), 1 / 12, 0.05);
   test.inDelta(d3.variance(d3.range(10000).map(randomBates(10))), 1 / 120, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBates(1.5))), 1 / 18, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBates(4.2))), 1 / 50.4, 0.05);
   test.end();
 });
 
@@ -24,6 +28,8 @@ tape("d3.randomBates(n) returns random numbers with a skewness of 0", function(t
   var randomBates = d3.randomBates.source(seedrandom("bb0bb470f346ff65"));
   test.inDelta(skewness(d3.range(10000).map(randomBates(1))), 0, 0.05);
   test.inDelta(skewness(d3.range(10000).map(randomBates(10))), 0, 0.05);
+  test.inDelta(skewness(d3.range(10000).map(randomBates(1.5))), 0, 0.05);
+  test.inDelta(skewness(d3.range(10000).map(randomBates(4.2))), 0, 0.05);
   test.end();
 });
 
@@ -31,5 +37,16 @@ tape("d3.randomBates(n) returns random numbers with a kurtosis of -6 / (5 * n)",
   var randomBates = d3.randomBates.source(seedrandom("3c21f0c8f5a8332c"));
   test.inDelta(kurtosis(d3.range(10000).map(randomBates(1))), -6 / 5, 0.05);
   test.inDelta(kurtosis(d3.range(10000).map(randomBates(10))), -6 / 50, 0.05);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBates(1.5))), -6 / 7.5, 0.05);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBates(4.2))), -6 / 21, 0.05);
+  test.end();
+});
+
+tape("d3.randomBates(0) is equivalent to d3.randomUniform()", function(test) {
+  var randomBates = d3.randomBates.source(seedrandom("3c21f0c8f5a8332c"));
+  test.inDelta(d3.mean(d3.range(10000).map(randomBates(0))), 0.5, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBates(0))), 1 / 12, 0.05);
+  test.inDelta(skewness(d3.range(10000).map(randomBates(0))), 0, 0.05);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBates(0))), -6 / 5, 0.05);
   test.end();
 });

--- a/test/bates-test.js
+++ b/test/bates-test.js
@@ -43,7 +43,7 @@ tape("d3.randomBates(n) returns random numbers with a kurtosis of -6 / (5 * n)",
 });
 
 tape("d3.randomBates(0) is equivalent to d3.randomUniform()", function(test) {
-  var randomBates = d3.randomBates.source(seedrandom("3c21f0c8f5a8332c"));
+  var randomBates = d3.randomBates.source(seedrandom("7f1d6e8020b157d6"));
   test.inDelta(d3.mean(d3.range(10000).map(randomBates(0))), 0.5, 0.05);
   test.inDelta(d3.variance(d3.range(10000).map(randomBates(0))), 1 / 12, 0.05);
   test.inDelta(skewness(d3.range(10000).map(randomBates(0))), 0, 0.05);

--- a/test/beta-test.js
+++ b/test/beta-test.js
@@ -1,0 +1,30 @@
+var tape = require("tape"),
+    seedrandom = require("seedrandom"),
+    d3 = Object.assign({}, require("../"), require("d3-array"));
+
+require("./inDelta");
+
+var mean = function(alpha, beta) { return alpha / (alpha + beta); };
+var variance = function(alpha, beta) { return (alpha * beta) / Math.pow(alpha + beta, 2) / (alpha + beta + 1); };
+
+tape("randomBeta(alpha, beta) returns random numbers with a mean of alpha / (alpha + beta)", function(test) {
+  var randomBeta = d3.randomBeta.source(seedrandom("1338e6f554b1da6d"));
+  test.inDelta(d3.mean(d3.range(10000).map(randomBeta(1, 1))), mean(1, 1), 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomBeta(1, 2))), mean(1, 2), 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomBeta(2, 1))), mean(2, 1), 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomBeta(3, 4))), mean(3, 4), 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomBeta(0.5, 0.5))), mean(0.5, 0.5), 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomBeta(2.7, 0.3))), mean(2.7, 0.3), 0.05);
+  test.end();
+});
+
+tape("randomBeta(alpha, beta) returns random numbers with a variance of (alpha * beta) / (alpha + beta)^2 / (alpha + beta + 1)", function(test) {
+  var randomBeta = d3.randomBeta.source(seedrandom("f86d852a93c73d91"));
+  test.inDelta(d3.variance(d3.range(10000).map(randomBeta(1, 1))), variance(1, 1), 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBeta(1, 2))), variance(1, 2), 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBeta(2, 1))), variance(2, 1), 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBeta(3, 4))), variance(3, 4), 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBeta(0.5, 0.5))), variance(0.5, 0.5), 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBeta(2.7, 0.3))), variance(2.7, 0.3), 0.05);
+  test.end();
+});

--- a/test/binomial-test.js
+++ b/test/binomial-test.js
@@ -4,7 +4,7 @@ var tape = require("tape"),
     kurtosis = require("./kurtosis"),
     d3 = Object.assign({}, require("../"), require("d3-array"));
 
-require("seedrandom");
+require("./inDelta");
 
 var mean = function(n, p) { return n * p; };
 var variance = function(n, p) { return n * p * (1 - p); };

--- a/test/binomial-test.js
+++ b/test/binomial-test.js
@@ -25,7 +25,7 @@ tape("randomBinomial(n, p) returns random binomial distributed numbers with a va
   var randomBinomial = d3.randomBinomial.source(seedrandom("c4af5ee918417093"));
   test.inDelta(d3.variance(d3.range(10000).map(randomBinomial(100, 1))), variance(100, 1), 0);
   test.inDelta(d3.variance(d3.range(10000).map(randomBinomial(100, .5))), variance(100, .5), 0.5);
-  test.inDelta(d3.variance(d3.range(10000).map(randomBinomial(100, .25))), variance(100, .25), 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomBinomial(100, .25))), variance(100, .25), 0.5);
   test.inDelta(d3.variance(d3.range(10000).map(randomBinomial(100, 0))), variance(100, 0), 0);
   test.inDelta(d3.variance(d3.range(10000).map(randomBinomial(0, 0))), variance(0, 0), 0);
   test.end();
@@ -47,14 +47,14 @@ tape("randomBinomial(n, p) returns random binomial distributed numbers with a sk
 
 tape("randomBinomial(n, p) returns random binomial distributed numbers with a kurtosis excess of (6 * p^2 - 6 * p - 1) / (n * p * (1 - p))", function(test) {
   var randomBinomial = d3.randomBinomial.source(seedrandom("n8qthobcylorx9b1"));
-  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .05))), kurt(100, .05), 0.05);
-  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .10))), kurt(100, .10), 0.05);
-  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .15))), kurt(100, .15), 0.05);
-  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .20))), kurt(100, .20), 0.05);
-  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .25))), kurt(100, .25), 0.05);
-  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .30))), kurt(100, .30), 0.05);
-  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .35))), kurt(100, .35), 0.05);
-  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .40))), kurt(100, .40), 0.05);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .05))), kurt(100, .05), 0.2);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .10))), kurt(100, .10), 0.1);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .15))), kurt(100, .15), 0.1);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .20))), kurt(100, .20), 0.1);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .25))), kurt(100, .25), 0.1);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .30))), kurt(100, .30), 0.1);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .35))), kurt(100, .35), 0.1);
+  test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .40))), kurt(100, .40), 0.1);
   test.inDelta(kurtosis(d3.range(10000).map(randomBinomial(100, .45))), kurt(100, .45), 0.05);
   test.end();
 });

--- a/test/cauchy-test.js
+++ b/test/cauchy-test.js
@@ -1,0 +1,18 @@
+var tape = require("tape"),
+    seedrandom = require("seedrandom"),
+    d3 = Object.assign({}, require("../"), require("d3-array"));
+
+require("./inDelta");
+
+// Since the Cauchy distribution is "pathological" in that no integral moments exist,
+// we simply test for the median, equivalent to the location parameter.
+
+tape("randomCauchy(a, b) returns random numbers with a median of a", function(test) {
+  var randomCauchy = d3.randomCauchy.source(seedrandom("60a03c00bbf7486f"));
+  test.inDelta(d3.median(d3.range(10000).map(randomCauchy())), 0, 0.05);
+  test.inDelta(d3.median(d3.range(10000).map(randomCauchy(5))), 5, 0.05);
+  test.inDelta(d3.median(d3.range(10000).map(randomCauchy(0, 4))), 0, 0.1);
+  test.inDelta(d3.median(d3.range(10000).map(randomCauchy(1, 3))), 1, 0.1);
+  test.inDelta(d3.median(d3.range(10000).map(randomCauchy(3, 1))), 3, 0.05);
+  test.end();
+});

--- a/test/gamma-test.js
+++ b/test/gamma-test.js
@@ -1,0 +1,56 @@
+var tape = require("tape"),
+    seedrandom = require("seedrandom"),
+    skewness = require("./skewness"),
+    kurtosis = require("./kurtosis"),
+    d3 = Object.assign({}, require("../"), require("d3-array"));
+
+require("./inDelta");
+
+tape("randomGamma(k) returns random numbers with a mean of k", function(test) {
+  var randomGamma = d3.randomGamma.source(seedrandom("ba00bda55400448e"));
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(0.1))), 0.1, 0.005);
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(0.5))), 0.5, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(1))), 1, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(2))), 2, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(10))), 10, 0.05);
+  test.end();
+});
+
+tape("randomGamma(k) returns random numbers with a variance of k", function(test) {
+  var randomGamma = d3.randomGamma.source(seedrandom("cb43934c1dcf650d"));
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(0.1))), 0.1, 0.005);
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(0.5))), 0.5, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(1))), 1, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(2))), 2, 0.1);
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(10))), 10, 0.5);
+  test.end();
+});
+
+tape("randomGamma(k) returns random numbers with a skewness of 2 / sqrt(k)", function(test) {
+  var randomGamma = d3.randomGamma.source(seedrandom("b9e71de4d94951e0"));
+  test.inDelta(skewness(d3.range(10000).map(randomGamma(0.1))), Math.sqrt(40), 1);
+  test.inDelta(skewness(d3.range(10000).map(randomGamma(0.5))), Math.sqrt(8), 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomGamma(1))), 2, 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomGamma(2))), Math.sqrt(2), 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomGamma(10))), Math.sqrt(0.4), 0.05);
+  test.end();
+});
+
+tape("randomGamma(k) returns random numbers with an excess kurtosis of 6 / k", function(test) {
+  var randomGamma = d3.randomGamma.source(seedrandom("d26f35533df47873"));
+  test.inDelta(kurtosis(d3.range(10000).map(randomGamma(0.1))), 60, 15);
+  test.inDelta(kurtosis(d3.range(10000).map(randomGamma(0.5))), 12, 3);
+  test.inDelta(kurtosis(d3.range(10000).map(randomGamma(1))), 6, 1.5);
+  test.inDelta(kurtosis(d3.range(10000).map(randomGamma(2))), 3, 0.75);
+  test.inDelta(kurtosis(d3.range(10000).map(randomGamma(10))), 0.6, 0.15);
+  test.end();
+});
+
+tape("randomGamma(k, theta) returns random numbers with a mean of k * theta and a variance of k * theta^2", function(test) {
+  var randomGamma = d3.randomGamma.source(seedrandom("22fe28c580a2f7d8"));
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(1,2))), 2, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(2,4))), 8, 0.1);
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(1,2))), 4, 0.2);
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(2,4))), 32, 1);
+  test.end();
+});

--- a/test/gamma-test.js
+++ b/test/gamma-test.js
@@ -48,9 +48,9 @@ tape("randomGamma(k) returns random numbers with an excess kurtosis of 6 / k", f
 
 tape("randomGamma(k, theta) returns random numbers with a mean of k * theta and a variance of k * theta^2", function(test) {
   var randomGamma = d3.randomGamma.source(seedrandom("22fe28c580a2f7d8"));
-  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(1,2))), 2, 0.05);
-  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(2,4))), 8, 0.1);
-  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(1,2))), 4, 0.2);
-  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(2,4))), 32, 1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(1, 2))), 2, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomGamma(2, 4))), 8, 0.1);
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(1, 2))), 4, 0.2);
+  test.inDelta(d3.variance(d3.range(10000).map(randomGamma(2, 4))), 32, 1);
   test.end();
 });

--- a/test/geometric-test.js
+++ b/test/geometric-test.js
@@ -38,7 +38,7 @@ tape("randomGeometric(p) returns random geometrically distributed numbers with a
 });
 
 tape("randomGeometric(p) returns random geometrically distributed numbers with a kurtosis excess of (p^2 - 6 * p + 6) / (1 - p).", function(test) {
-  var randomGeometric = d3.randomGeometric.source(seedrandom("d5cb594f444fc692"));
+  var randomGeometric = d3.randomGeometric.source(seedrandom("55cb594f444fc692"));
   test.inDelta(kurtosis(d3.range(10000).map(randomGeometric(.5))), kurt(.5), 0.1 * kurt(.5));
   test.inDelta(kurtosis(d3.range(10000).map(randomGeometric(0.25))), kurt(0.25), 0.1 * kurt(0.25));
   test.inDelta(kurtosis(d3.range(10000).map(randomGeometric(0.125))), kurt(0.125), 0.1 * kurt(0.125));

--- a/test/irwinHall-test.js
+++ b/test/irwinHall-test.js
@@ -10,6 +10,8 @@ tape("d3.randomIrwinHall(n) returns random numbers with a mean of n / 2", functi
   var randomIrwinHall = d3.randomIrwinHall.source(seedrandom("f330fbece4c1c99f"));
   test.inDelta(d3.mean(d3.range(10000).map(randomIrwinHall(1))), 1 / 2, 0.05);
   test.inDelta(d3.mean(d3.range(10000).map(randomIrwinHall(10))), 10 / 2, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomIrwinHall(1.5))), 1.5 / 2, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomIrwinHall(4.2))), 4.2 / 2, 0.05);
   test.end();
 });
 
@@ -17,6 +19,8 @@ tape("d3.randomIrwinHall(n) returns random numbers with a variance of n / 12", f
   var randomIrwinHall = d3.randomIrwinHall.source(seedrandom("c4af5ee918417093"));
   test.inDelta(d3.variance(d3.range(10000).map(randomIrwinHall(1))), 1 / 12, 0.05);
   test.inDelta(d3.variance(d3.range(10000).map(randomIrwinHall(10))), 10 / 12, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomIrwinHall(1.5))), 1.5 / 12, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomIrwinHall(4.2))), 4.2 / 12, 0.05);
   test.end();
 });
 
@@ -24,6 +28,8 @@ tape("d3.randomIrwinHall(n) returns random numbers with a skewness of 0", functi
   var randomIrwinHall = d3.randomIrwinHall.source(seedrandom("bb0bb470f346ff65"));
   test.inDelta(skewness(d3.range(10000).map(randomIrwinHall(1))), 0, 0.05);
   test.inDelta(skewness(d3.range(10000).map(randomIrwinHall(10))), 0, 0.05);
+  test.inDelta(skewness(d3.range(10000).map(randomIrwinHall(1.5))), 0, 0.05);
+  test.inDelta(skewness(d3.range(10000).map(randomIrwinHall(4.2))), 0, 0.05);
   test.end();
 });
 
@@ -31,5 +37,7 @@ tape("d3.randomIrwinHall(n) returns random numbers with a kurtosis of -6 / (5 * 
   var randomIrwinHall = d3.randomIrwinHall.source(seedrandom("3c21f0c8f5a8332c"));
   test.inDelta(kurtosis(d3.range(10000).map(randomIrwinHall(1))), -6 / 5, 0.05);
   test.inDelta(kurtosis(d3.range(10000).map(randomIrwinHall(10))), -6 / 50, 0.05);
+  test.inDelta(kurtosis(d3.range(10000).map(randomIrwinHall(1.5))), -6 / 7.5, 0.05);
+  test.inDelta(kurtosis(d3.range(10000).map(randomIrwinHall(4.2))), -6 / 21, 0.05);
   test.end();
 });

--- a/test/logistic-test.js
+++ b/test/logistic-test.js
@@ -1,0 +1,49 @@
+var tape = require("tape"),
+    seedrandom = require("seedrandom"),
+    skewness = require("./skewness"),
+    kurtosis = require("./kurtosis"),
+    d3 = Object.assign({}, require("../"), require("d3-array"));
+
+require("./inDelta");
+
+var variance = function(a, b) { return Math.pow(Math.PI * b, 2) / 3; };
+
+tape("randomLogistic(a, b) returns random numbers with a mean of a", function(test) {
+  var randomLogistic = d3.randomLogistic.source(seedrandom("df715f110c264e9"));
+  test.inDelta(d3.mean(d3.range(10000).map(randomLogistic())), 0, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomLogistic(5))), 5, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomLogistic(0, 4))), 0, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomLogistic(1, 3))), 1, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomLogistic(3, 1))), 3, 0.05);
+  test.end();
+});
+
+tape("randomLogistic(a, b) returns random numbers with a variance of (b * pi)^2 / 3", function(test) {
+  var randomLogistic = d3.randomLogistic.source(seedrandom("7e99b2b1fb2200a4"));
+  test.inDelta(d3.variance(d3.range(10000).map(randomLogistic())), variance(0, 1), 0.2);
+  test.inDelta(d3.variance(d3.range(10000).map(randomLogistic(5))), variance(5, 1), 0.2);
+  test.inDelta(d3.variance(d3.range(10000).map(randomLogistic(0, 4))), variance(0, 4), 1);
+  test.inDelta(d3.variance(d3.range(10000).map(randomLogistic(1, 3))), variance(1, 3), 1);
+  test.inDelta(d3.variance(d3.range(10000).map(randomLogistic(3, 1))), variance(3, 1), 0.2);
+  test.end();
+});
+
+tape("randomLogistic(a, b) returns random numbers with a skewness of zero", function(test) {
+  var randomLogistic = d3.randomLogistic.source(seedrandom("3970da720513ac2f"));
+  test.inDelta(skewness(d3.range(10000).map(randomLogistic())), 0, 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomLogistic(5))), 0, 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomLogistic(0, 4))), 0, 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomLogistic(1, 3))), 0, 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomLogistic(3, 1))), 0, 0.1);
+  test.end();
+});
+
+tape("randomLogistic(a, b) returns random numbers with an excess kurtosis of 1.2", function(test) {
+  var randomLogistic = d3.randomLogistic.source(seedrandom("6f0a0bfb0e31192e"));
+  test.inDelta(kurtosis(d3.range(10000).map(randomLogistic())), 1.2, 0.3);
+  test.inDelta(kurtosis(d3.range(10000).map(randomLogistic(5))), 1.2, 0.3);
+  test.inDelta(kurtosis(d3.range(10000).map(randomLogistic(0, 4))), 1.2, 0.3);
+  test.inDelta(kurtosis(d3.range(10000).map(randomLogistic(1, 3))), 1.2, 0.3);
+  test.inDelta(kurtosis(d3.range(10000).map(randomLogistic(3, 1))), 1.2, 0.3);
+  test.end();
+});

--- a/test/poisson-test.js
+++ b/test/poisson-test.js
@@ -1,0 +1,59 @@
+var tape = require("tape"),
+    seedrandom = require("seedrandom"),
+    skewness = require("./skewness"),
+    kurtosis = require("./kurtosis"),
+    d3 = Object.assign({}, require("../"), require("d3-array"));
+
+require("./inDelta");
+
+// Ten times the default number of samples are taken for the lambda = 0.001 tests,
+// since otherwise the very small expected number of non-zero samples would
+// wildly influence summary statistics.
+
+tape("randomPoisson(lambda) returns random numbers with a mean of lambda", function(test) {
+  var randomPoisson = d3.randomPoisson.source(seedrandom("572ccd4d37773583"));
+  test.inDelta(d3.mean(d3.range(100000).map(randomPoisson(0.001))), 0.001, 0.0005);
+  test.inDelta(d3.mean(d3.range(10000).map(randomPoisson(0.1))), 0.1, 0.01);
+  test.inDelta(d3.mean(d3.range(10000).map(randomPoisson(0.5))), 0.5, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomPoisson(1))), 1, 0.05);
+  test.inDelta(d3.mean(d3.range(10000).map(randomPoisson(2))), 2, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomPoisson(10))), 10, 0.5);
+  test.inDelta(d3.mean(d3.range(10000).map(randomPoisson(1000))), 1000, 20);
+  test.end();
+});
+
+tape("randomPoisson(lambda) returns random numbers with a variance of lambda", function(test) {
+  var randomPoisson = d3.randomPoisson.source(seedrandom("7bd1f251244fbded"));
+  test.inDelta(d3.variance(d3.range(100000).map(randomPoisson(0.001))), 0.001, 0.0005);
+  test.inDelta(d3.variance(d3.range(10000).map(randomPoisson(0.1))), 0.1, 0.01);
+  test.inDelta(d3.variance(d3.range(10000).map(randomPoisson(0.5))), 0.5, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomPoisson(1))), 1, 0.05);
+  test.inDelta(d3.variance(d3.range(10000).map(randomPoisson(2))), 2, 0.1);
+  test.inDelta(d3.variance(d3.range(10000).map(randomPoisson(10))), 10, 0.5);
+  test.inDelta(d3.variance(d3.range(10000).map(randomPoisson(1000))), 1000, 20);
+  test.end();
+});
+
+tape("randomPoisson(lambda) returns random numbers with a skewness of 1 / sqrt(lambda)", function(test) {
+  var randomPoisson = d3.randomPoisson.source(seedrandom("71b5d608957d974b"));
+  test.inDelta(skewness(d3.range(100000).map(randomPoisson(0.001))), 31.6, 5);
+  test.inDelta(skewness(d3.range(10000).map(randomPoisson(0.1))), 3.16, 0.2);
+  test.inDelta(skewness(d3.range(10000).map(randomPoisson(0.5))), 1.414, 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomPoisson(1))), 1, 0.1);
+  test.inDelta(skewness(d3.range(10000).map(randomPoisson(2))), 0.707, 0.05);
+  test.inDelta(skewness(d3.range(10000).map(randomPoisson(10))), 0.316, 0.05);
+  test.inDelta(skewness(d3.range(10000).map(randomPoisson(1000))), 0.0316, 0.05);
+  test.end();
+});
+
+tape("randomPoisson(lambda) returns random numbers with a kurtosis excess of 1 / lambda", function(test) {
+  var randomPoisson = d3.randomPoisson.source(seedrandom("fa7e2c8be3b90c1e"));
+  test.inDelta(kurtosis(d3.range(100000).map(randomPoisson(0.001))), 1000, 200);
+  test.inDelta(kurtosis(d3.range(10000).map(randomPoisson(0.1))), 10, 2);
+  test.inDelta(kurtosis(d3.range(10000).map(randomPoisson(0.5))), 2, 0.5);
+  test.inDelta(kurtosis(d3.range(10000).map(randomPoisson(1))), 1, 0.5);
+  test.inDelta(kurtosis(d3.range(10000).map(randomPoisson(2))), 0.5, 0.2);
+  test.inDelta(kurtosis(d3.range(10000).map(randomPoisson(10))), 0.1, 0.1);
+  test.inDelta(kurtosis(d3.range(10000).map(randomPoisson(1000))), 0.001, 0.1);
+  test.end();
+});

--- a/test/weibull-test.js
+++ b/test/weibull-test.js
@@ -6,20 +6,28 @@ require("./inDelta");
 
 tape("randomWeibull() returns random numbers with the specified mean", function (test) {
   var randomWeibull = d3.randomWeibull.source(seedrandom("5125ce415d4cd8e"));
-  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1, 0.3))), 9.260, 1);
-  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1, 1))), 1, 0.1);
-  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1, 3))), 0.893, 0.1);
-  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1, 9))), 0.947, 0.1);
-  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(2, 4))), 1.813, 0.2);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(9))), 0.947, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(3))), 0.893, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1))), 1, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(0.3))), 9.260, 1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(0))), 0.577, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(-3))), 1.354, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(-9))), 1.078, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(4, 1, 2))), 2.813, 0.2);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(-4, 1, 2))), 3.451, 0.2);
   test.end();
 });
 
 tape("randomWeibull() returns random numbers with the specified deviation", function (test) {
   var randomWeibull = d3.randomWeibull.source(seedrandom("2d61cfee9eb78d19"));
-  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1, 0.3))), 50, 10);
-  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1, 1))), 1, 0.2);
-  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1, 3))), 0.324, 0.06);
-  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1, 9))), 0.126, 0.02);
-  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(2, 4))), 0.509, 0.1);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(9))), 0.126, 0.02);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(3))), 0.324, 0.06);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1))), 1, 0.2);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(0.3))), 50, 10);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(0))), 1.282, 0.05);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(-3))), 0.919, 0.1);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(-9))), 0.169, 0.02);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(4, 1, 2))), 0.509, 0.1);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(-4, 1, 2))), 1.0408, 0.1);
   test.end();
 });

--- a/test/weibull-test.js
+++ b/test/weibull-test.js
@@ -1,0 +1,25 @@
+var tape = require("tape"),
+    seedrandom = require("seedrandom"),
+    d3 = Object.assign({}, require("../"), require("d3-array"));
+
+require("./inDelta");
+
+tape("randomWeibull() returns random numbers with the specified mean", function (test) {
+  var randomWeibull = d3.randomWeibull.source(seedrandom("5125ce415d4cd8e"));
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1, 0.3))), 9.260, 1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1, 1))), 1, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1, 3))), 0.893, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(1, 9))), 0.947, 0.1);
+  test.inDelta(d3.mean(d3.range(10000).map(randomWeibull(2, 4))), 1.813, 0.2);
+  test.end();
+});
+
+tape("randomWeibull() returns random numbers with the specified deviation", function (test) {
+  var randomWeibull = d3.randomWeibull.source(seedrandom("2d61cfee9eb78d19"));
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1, 0.3))), 50, 10);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1, 1))), 1, 0.2);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1, 3))), 0.324, 0.06);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(1, 9))), 0.126, 0.02);
+  test.inDelta(d3.deviation(d3.range(10000).map(randomWeibull(2, 4))), 0.509, 0.1);
+  test.end();
+});


### PR DESCRIPTION
Distributions added:

* [Gamma](https://en.wikipedia.org/wiki/Gamma_distribution) – waiting time to failure
* [Beta](https://en.wikipedia.org/wiki/Beta_distribution) – derived from the gamma, Bayesian inference, order statistics (notebook [here](https://observablehq.com/@parcly-taxel/the-gamma-and-beta-distributions))
* [Generalised extreme value](https://en.wikipedia.org/wiki/Generalized_extreme_value_distribution) (Fréchet/Gumbel/Weibull) – particle size, extreme events, closes #27 (notebook [here](https://observablehq.com/@parcly-taxel/frechet-gumbel-weibull))
* [Cauchy](https://en.wikipedia.org/wiki/Cauchy_distribution) and [logistic](https://en.wikipedia.org/wiki/Logistic_distribution) – spectroscopy, logistic regression (notebook [here](https://observablehq.com/@parcly-taxel/cauchy-and-logistic-distributions))
* [Poisson](https://en.wikipedia.org/wiki/Poisson_distribution) – the Poisson point process (which itself occurs in a lot of places), closes #5 _efficiently_ (notebook [here](https://observablehq.com/@parcly-taxel/the-poisson-distribution))

Other changes:

* Irwin–Hall distribution generalised to real arguments – closes #23
* randomGeometric now allows 0 as an argument
* O(log log _n_) binomial generator, improved from O(_n_) (notebook [here](https://observablehq.com/@parcly-taxel/faster-binomial-variates) – the actual code is slightly simpler because randomGeometric(0) is now allowed, as above)
* Math.log1p() used instead for Math.log() for greater accuracy when generating exponential variates – `-Math.log1p(-source())` is guaranteed to generate an _accurate, finite_ exponential(1) variate